### PR TITLE
Add more maping for custom profile fields #24

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -98,6 +98,8 @@ function xmldb_local_cnw_smartcohort_upgrade($oldversion) {
         $customfields = [];
         foreach ($cfs as $cf) {
             $customfields[$cf->shortname] = $cf->id;
+            // Custom profile fields can be stored with their prefix.
+            $customfields['profile_field_' . $cf->shortname] = $cf->id;
         }
 
         // Convert old filters to new filters.


### PR DESCRIPTION
Closes #24 

Unfortunately I don't think there's a way to fix this properly for those already upgraded since the profile data is lost. I'm not sure if $cf->shortname is a possible name in the existing table or not so I've left it for now. 